### PR TITLE
moved user image from social_provider to user model.

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,7 +9,7 @@ class Tag < ActiveRecord::Base
   has_many :similar_tags, class_name: 'Tag', foreign_key: 'representative_id'
   belongs_to :representative, class_name: 'Tag'
 
-  before_save :downcase
+  before_save :downcase!, :strip!
   after_create :push_representative_assignment_to_sidekiq
   after_update :push_subscription_update_to_sidekiq, if: :representative_id_changed?
 
@@ -47,7 +47,11 @@ class Tag < ActiveRecord::Base
     end
   end
 
-  def downcase
+  def strip!
+    name.strip!
+  end
+
+  def downcase!
     name.downcase!
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ActiveRecord::Base
     user = where("email LIKE :email", email: grabbed).first_or_create do |u|
       u.name= auth.info.name
       u.email= auth.info.email
+      u.image = auth.info.image
     end
     return user unless user.valid?
     user.social_providers.from_social(auth)
@@ -28,10 +29,6 @@ class User < ActiveRecord::Base
 
   def refresh_token
     TokenManager.generate_token(self.id)
-  end
-
-  def image
-    social_providers.first.try(:profile_picture)
   end
 
   def can_vote?

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -1,3 +1,2 @@
-json.extract! user, :id, :name, :points
-json.image user.image
+json.extract! user, :id, :name, :points, :image
 json.url user_url(user, format: :json)

--- a/db/migrate/20160401195400_add_image_to_users.rb
+++ b/db/migrate/20160401195400_add_image_to_users.rb
@@ -1,0 +1,5 @@
+class AddImageToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :image, :string
+  end
+end

--- a/db/migrate/20160401195419_move_user_image_from_social_provider.rb
+++ b/db/migrate/20160401195419_move_user_image_from_social_provider.rb
@@ -1,0 +1,15 @@
+class MoveUserImageFromSocialProvider < ActiveRecord::Migration
+  def up
+    User.includes(:social_providers).find_each do |user|
+      image = user.social_providers.first.try(:profile_picture)
+      user.update(image: image)
+    end
+  end
+
+  def down
+    User.includes(:social_providers).find_each do |user|
+      image = user.image
+      user.social_providers.first.update(profile_picture: image)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160323093827) do
+ActiveRecord::Schema.define(version: 20160401195419) do
 
   create_table "answers", force: :cascade do |t|
     t.integer  "user_id"
@@ -65,9 +65,9 @@ ActiveRecord::Schema.define(version: 20160323093827) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.string   "token"
-    t.string   "profile_picture"
     t.string   "profile_url"
     t.string   "email"
+    t.string   "profile_picture"
   end
 
   add_index "social_providers", ["user_id"], name: "index_social_providers_on_user_id"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 20160323093827) do
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.boolean  "active"
+    t.string   "image"
   end
 
   create_table "votes", force: :cascade do |t|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     name { Faker::Name.name }
     points { Faker::Number.number(2) }
     sequence(:email) { |n| "#{Faker::Lorem.word}#{n}@andela.com" }
+    image { Faker::Avatar.image }
 
     factory :user_with_comments_on_question do
       transient do
@@ -12,6 +13,10 @@ FactoryGirl.define do
       after(:create) do |user, evaluator|
         create_list(:comment_on_question, evaluator.comments_count, user: user)
       end
+    end
+
+    trait :without_image do
+      image nil
     end
 
     factory :user_with_comments_on_answer do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe Tag, type: :model do
     end
   end
 
+  describe "#strip!" do
+    let(:tag_name) { "tag"}
+    let(:subject) { create(:tag, name: "        #{tag_name} ")}
+
+    it "strips all whitespaces from the name" do
+      expect(subject.name).to eql(tag_name)
+    end
+  end
+
+  describe "#downcase!" do
+    let(:tag_name) { "RUBY-ON-RAILS"}
+    let(:subject) { create(:tag, name: tag_name)}
+
+    it "strips all whitespaces from the name" do
+      expect(subject.name).to eql(tag_name.downcase)
+    end
+  end
+
   describe "#push_subscription_update_to_sidekiq" do
     let(:subject) { create(:tag, name: 'tag') }
     let(:new_rep) { create(:tag, name: 'tag') }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Tag, type: :model do
     let(:tag_name) { "RUBY-ON-RAILS"}
     let(:subject) { create(:tag, name: tag_name)}
 
-    it "strips all whitespaces from the name" do
+    it "downcases the tag name" do
       expect(subject.name).to eql(tag_name.downcase)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe User, type: :model do
 
     it "returns the url to user picture if user has picture" do
       image = Faker::Avatar.image
-      user.social_providers.create(profile_picture: image)
+      user.update(image: image)
       expect(user.image).not_to be_nil
       expect(user.image).to eql image
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe User, type: :model do
   end
 
   describe ":get_picture" do
+    let(:user) { create(:user, :without_image) }
     it "returns nil if user has no picture" do
       expect(user.image).to be_nil
     end


### PR DESCRIPTION
There was a thought around removing the `image` || `profile_picture` from SocialProvider, but I thought since we'd still be getting rid of the social_providers table, that should still be left till we finally get rid of it